### PR TITLE
upload video.m4v and video.webm, have piwigo consider it's the same vide...

### DIFF
--- a/template/jplayer.tpl
+++ b/template/jplayer.tpl
@@ -5,13 +5,16 @@
     $("#jquery_jplayer_1").jPlayer( {
       ready: function () {
         $(this).jPlayer("setMedia", {
-          {/literal}{$TYPE}{literal}: {/literal}"{$JP_MEDIA_URL}"{literal},
-          {/literal}{if $JP_POSTER}{literal}
+          {/literal}{$TYPE}{literal}: {/literal}"{$JP_MEDIA_URL}"{literal},{/literal}
+          {if $ALT_TYPE}
+          {$ALT_TYPE}{literal}: {/literal}"{$ALT_JP_MEDIA_URL}"{literal},{/literal}
+          {/if}
+          {if $JP_POSTER}{literal}
           poster: {/literal}"{$JP_POSTER}"{literal},
           {/literal}{/if}{literal}
         }).jPlayer({/literal}"{$AUTOPLAY}"{literal});
       },
-      supplied: {/literal}"{$TYPE}"{literal},
+      supplied: {/literal}"{$TYPE}{if $ALT_TYPE}{literal},{/literal}{$ALT_TYPE}{/if}"{literal},
       swfPath: {/literal}"{$JPLAYER_PATH}/js/"{literal},
       {/literal}{if $IS_VIDEO}{literal}
       size: {


### PR DESCRIPTION
...o and have jplayer choose the best format for your browser

this contribution is specific to the case where user adds video.webm and video.m4v (do theora videos really matter ?)

The contribution is made in 2 parts :
- give 2 types and 2 urls to jplayer when 2 types of videos are avalable
- filter the thumbnails that represent a video already having a thumbnail

It works fine for my gallery, please review carefully, I'm not a php developer ;-)
