### PR TITLE
Don't load jPlayer if extension is not a known media extension

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -96,7 +96,6 @@ function render_media($content, $picture)
 	if (!in_array($extension, $conf['media_ext'])) {
 		return $content;
 	}
-	// if video
     else if(isset($fileinfo['video'])) {
         // -- video file --
         $is_video = True;
@@ -117,7 +116,6 @@ function render_media($content, $picture)
             $height = intval( 9 * ($width / 16 ));
         } 
     }
-	// if audio only
     else {
         // -- audio only file --
         if ($extension == 'webm') $extension = 'webma';

--- a/main.inc.php
+++ b/main.inc.php
@@ -18,7 +18,7 @@ global $conf;
 
 // Register the allowed extentions to the global conf in order
 // to sync them with other contents
-$jp_extensions = array(
+$conf['media_ext'] = array(
     'mp3', 
     'm4a', 
     'ogg', 
@@ -33,7 +33,7 @@ $jp_extensions = array(
     'webmv',
     'flv',
 );
-$conf['file_ext'] = array_merge($conf['file_ext'], $jp_extensions);
+$conf['file_ext'] = array_merge($conf['file_ext'], $conf['media_ext']);
 
 // Hook on to an event to display videos as standard images
 add_event_handler('render_element_content', 'render_media', 40, 2 );
@@ -92,8 +92,12 @@ function render_media($content, $picture)
     $basename = strtolower(get_filename_wo_extension($picture['current']['path']));
     $is_video = False;
 
-
-    if(isset($fileinfo['video'])) {
+	// if not a media extension, do nothing
+	if (!in_array($extension, $conf['media_ext'])) {
+		return $content;
+	}
+	// if video
+    else if(isset($fileinfo['video'])) {
         // -- video file --
         $is_video = True;
         if ($extension == 'webm') $extension = 'webmv'; 
@@ -113,6 +117,7 @@ function render_media($content, $picture)
             $height = intval( 9 * ($width / 16 ));
         } 
     }
+	// if audio only
     else {
         // -- audio only file --
         if ($extension == 'webm') $extension = 'webma';


### PR DESCRIPTION
On my Piwigo install, I have some non-media files (not photos, audio, or video)...like ZIP and PDF and so on. jPlayer was trying to play these [incompatible] files, since it was only testing on whether something was an image.

This change will prevent the jPlayer from loading unless the file is a known audio/video file type. For unknown file types, it will fall back on built-in Piwigo (a ? icon and a save/download option).
